### PR TITLE
Improves efficiency (and fix a bug ...)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ Evolutionary = "86b6b26d-c046-49b6-aa0b-5f0f74682bd6"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ThreadPools = "b189fb0b-2eb5-4ed4-bc0c-d34c51242431"
+Unrolled = "9602ed7d-8fef-5bc8-8597-8f21381861e8"
 
 [compat]
 ConstraintDomains = "0.2"
@@ -17,6 +18,7 @@ Dictionaries = "0.3"
 Evolutionary = "0.9"
 OrderedCollections = "1"
 ThreadPools = "2"
+Unrolled = "0.1"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CompositionalNetworks"
 uuid = "4b67e4b5-442d-4ef5-b760-3f5df3a57537"
 authors = ["Jean-François Baffier"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 ConstraintDomains = "5800fd60-8556-4464-8d61-84ebf7a0bedb"

--- a/src/CompositionalNetworks.jl
+++ b/src/CompositionalNetworks.jl
@@ -9,19 +9,26 @@ using Random
 using ThreadPools
 
 # Exports utilities
-export lazy, lazy_param
 export hamming
-export minkowski
+export lazy
+export lazy_param
 export manhattan
+export minkowski
 export regularization
 
 # Export ICN
 export ICN
+export aggregation_layer
+export arithmetic_layer
+export comparison_layer
+export compose
+export compose_to_file!
+export explore_learn_compose
+export learn_compose
 export optimize!
-export compose, show_composition
-export compose_to_file!, explore_learn_compose, learn_compose
-export transformation_layer, arithmetic_layer, aggregation_layer, comparison_layer
+export show_composition
 export show_layers
+export transformation_layer
 
 # Include utils
 include("utils.jl")

--- a/src/CompositionalNetworks.jl
+++ b/src/CompositionalNetworks.jl
@@ -7,6 +7,7 @@ using Evolutionary
 using OrderedCollections
 using Random
 using ThreadPools
+using Unrolled
 
 # Exports utilities
 export hamming

--- a/src/aggregation.jl
+++ b/src/aggregation.jl
@@ -2,7 +2,7 @@
     ag_sum(x)
 Aggregate through `+` a vector into a single scalar.
 """
-ag_sum(x) = reduce(+, x)
+ag_sum(x) = sum(x)
 
 """
     ag_count_positive(x)

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -2,7 +2,7 @@
     ar_sum(x)
 Reduce `k = length(x)` vectors through sum to a single vector.
 """
-ar_sum(x) = reduce((y, z) -> y .+ z, x)
+ar_sum(x) = sum(x)
 
 """
     ar_prod(x)

--- a/src/comparison.jl
+++ b/src/comparison.jl
@@ -27,7 +27,7 @@ co_param_minus_val(x; param, dom_size=0, nvars=0) = max(0.0, param - x)
 Compute an euclidian norm with domain size `dom_size`, weigthed by `param`, of a scalar.
 """
 function co_euclidian_param(x; param, dom_size, nvars=0)
-    return x == param ? 0.0 : (1.0 + abs(x - param) \ dom_size)
+    return x == param ? 0.0 : (1.0 + abs(x - param) / dom_size)
 end
 
 """

--- a/src/icn.jl
+++ b/src/icn.jl
@@ -123,7 +123,19 @@ function _compose(icn::ICN)
     end
 
     l = length(funcs[1])
-    composition = (x; param=nothing, dom_size) -> fill(x, l) .|> map(f -> (y -> f(y; param=param)), funcs[1]) |> funcs[2][1] |> funcs[3][1] |> (y -> funcs[4][1](y; param=param, dom_size=dom_size, nvars=length(x)))
+
+    composition = (x; X=zeros(length(x), l), param=nothing, dom_size) -> if l == 1
+        x |> (y -> funcs[1][1](y; param)) |> funcs[3][1] |>
+        (y -> funcs[4][1](y; param, dom_size, nvars=length(x)))
+    else
+        fill!(@view(X[1:length(x), :]), 0.0)
+        tr_in(Tuple(funcs[1]), X, x, param)
+        for i in 1:length(x)
+            X[i,1] = funcs[2][1](@view X[i,:])
+        end
+        funcs[3][1](@view X[:, 1]) |> (y -> funcs[4][1](y; param, dom_size, nvars=length(x)))
+    end
+
     return composition, symbols
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -61,3 +61,17 @@ end
 function incsert!(d::Dictionary, ind)
     set!(d, ind, isassigned(d, ind) ? d[ind] + 1 : 1)
 end
+
+@unroll function tr_in(tr, X, x, param)
+    @unroll for i in 1:length(tr)
+        X[:,i] = tr[i](x; param)
+    end
+end
+
+# TODO: look for a length limit that make it slow or space-comsuming
+# TODO: handle SMatrix
+# @unroll function ar_in(ar, X, x)
+#     @unroll for i in 1:length(x)
+#         X[i, 1] = ar(@view X[i, :])
+#     end
+# end

--- a/test/layers.jl
+++ b/test/layers.jl
@@ -158,23 +158,25 @@ for (f, results) in funcs_vars
 end
 
 funcs_param_dom = [
-    CN.co_euclidian_param => [3.5, 2.0],
+    CN.co_euclidian_param => [1.4, 2.0],
 ]
 
 for (f, results) in funcs_param_dom
     @info f
     for (key, vals) in enumerate(data)
+        @info "Updated" f(vals.first, param=vals.second[1], dom_size=vals.second[2]) results key
         @test f(vals.first, param=vals.second[1], dom_size=vals.second[2]) ≈ results[key]
     end
 end
 
 funcs_dom = [
-    CN.co_euclidian => [8 / 3, 2.0],
+    CN.co_euclidian => [1.6, 2.0],
 ]
 
 for (f, results) in funcs_dom
     @info f
     for (key, vals) in enumerate(data)
+        @info "Updated" f(vals.first, dom_size=vals.second[2]) results key
         @test f(vals.first, dom_size=vals.second[2]) ≈ results[key]
     end
 end


### PR DESCRIPTION
This PR goal is to improve the efficiency of compositions output by ICN. To-test list
- [x] Improve individual operations
- [x] Transform the 3 first layers [input vector > k transformed vectors > 1 vector (arithmetic op) > 1 scalar (aggregation)] into something more linear algebraic
  - [x] If `k == 1`, make use of [mapreduce](https://docs.julialang.org/en/v1/base/collections/#Base.mapreduce-Tuple{Any,%20Any,%20Any}) for `ag_sum` and `x |> map |> count` for ag_count to avoid allocations as the arithmetic layer can be ignored
  - [x] otherwise make a vector `v` to collect each transformation op result (`map`) successively and use the arithmetic op to update `v`
  - [x] another option that allocate more (or not, see next sentence) but could be faster being to make a Matrix of k columns and use LinearAlgebra module to compute fast transformation on it. This matrix could be given as input option to the composition (output of the icn), and could be then stored in the inner state of the solver (so 1 allocation at start only)
- [x] Compare the different options and take the most efficient (speed and allocations are criteria). Use magic_square as a bench

Bonus: fix a bug in operations using euclidean norm